### PR TITLE
Fix deprecation warnings with latest dry-configurable gem (0.13)

### DIFF
--- a/lib/tdlib-ruby.rb
+++ b/lib/tdlib-ruby.rb
@@ -18,19 +18,19 @@ module TD
   setting :client do
     setting :api_id, &:to_i
     setting :api_hash
-    setting :use_test_dc, false
-    setting :database_directory, "#{Dir.home}/.tdlib-ruby/db"
-    setting :files_directory, "#{Dir.home}/.tdlib-ruby/data"
-    setting :use_file_database, true
-    setting :use_chat_info_database, true
-    setting :use_secret_chats, true
-    setting :use_message_database, true
-    setting :system_language_code, 'en'
-    setting :device_model, 'Ruby TD client'
-    setting :system_version, 'Unknown'
-    setting :application_version, '1.0'
-    setting :enable_storage_optimizer, true
-    setting :ignore_file_names, false
+    setting :use_test_dc, default: false
+    setting :database_directory, default: "#{Dir.home}/.tdlib-ruby/db"
+    setting :files_directory, default: "#{Dir.home}/.tdlib-ruby/data"
+    setting :use_file_database, default: true
+    setting :use_chat_info_database, default: true
+    setting :use_secret_chats, default: true
+    setting :use_message_database, default: true
+    setting :system_language_code, default: 'en'
+    setting :device_model, default: 'Ruby TD client'
+    setting :system_version, default: 'Unknown'
+    setting :application_version, default: '1.0'
+    setting :enable_storage_optimizer, default: true
+    setting :ignore_file_names, default: false
   end
 end
 

--- a/lib/tdlib-ruby.rb
+++ b/lib/tdlib-ruby.rb
@@ -16,7 +16,7 @@ module TD
   setting :encryption_key
 
   setting :client do
-    setting :api_id, &:to_i
+    setting :api_id, constructor: ->(v) { v.to_i }
     setting :api_hash
     setting :use_test_dc, default: false
     setting :database_directory, default: "#{Dir.home}/.tdlib-ruby/db"

--- a/lib/tdlib/client.rb
+++ b/lib/tdlib/client.rb
@@ -70,7 +70,7 @@ class TD::Client
       result = nil
       mutex = Mutex.new
 
-      @update_manager << TD::UpdateHandler.new(TD::Types::Base, extra, disposable: true) do |update|
+      @update_manager << TD::UpdateHandler.new(TD::Types::Base, extra, true) do |update|
         mutex.synchronize do
           result = update
           condition.signal

--- a/lib/tdlib/update_handler.rb
+++ b/lib/tdlib/update_handler.rb
@@ -3,7 +3,7 @@ class TD::UpdateHandler
 
   attr_reader :update_type, :extra
 
-  def initialize(update_type, extra = nil, disposable: false, &action)
+  def initialize(update_type, extra = nil, disposable = nil, &action)
     super()
 
     @action = action

--- a/lib/tdlib/version.rb
+++ b/lib/tdlib/version.rb
@@ -1,4 +1,4 @@
 module TD
   # tdlib-ruby version
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 end

--- a/lib/tdlib/version.rb
+++ b/lib/tdlib/version.rb
@@ -1,4 +1,4 @@
 module TD
   # tdlib-ruby version
-  VERSION = "3.0.3"
+  VERSION = "3.0.4"
 end

--- a/tdlib-ruby.gemspec
+++ b/tdlib-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'dry-configurable', '~> 0.9'
+  gem.add_runtime_dependency 'dry-configurable', '~> 0.13'
   gem.add_runtime_dependency 'concurrent-ruby',  '~> 1.1'
   gem.add_runtime_dependency 'ffi',              '~> 1.0'
   gem.add_runtime_dependency 'tdlib-schema'


### PR DESCRIPTION
Since last dry-configurable gem there are some deprecations on how to pass blocks and default values, so I made the changes accordingly to the code, and increased patch version as well as dependency gemspec