### PR TITLE
remove check encryption key

### DIFF
--- a/lib/tdlib-ruby.rb
+++ b/lib/tdlib-ruby.rb
@@ -29,8 +29,6 @@ module TD
     setting :device_model, 'Ruby TD client'
     setting :system_version, 'Unknown'
     setting :application_version, '1.0'
-    setting :enable_storage_optimizer, true
-    setting :ignore_file_names, false
   end
 end
 

--- a/lib/tdlib/client.rb
+++ b/lib/tdlib/client.rb
@@ -36,13 +36,10 @@ class TD::Client
     on TD::Types::Update::AuthorizationState do |update|
       case update.authorization_state
       when TD::Types::AuthorizationState::WaitTdlibParameters
-        set_tdlib_parameters(parameters: TD::Types::TdlibParameters.new(**@config))
-      when TD::Types::AuthorizationState::WaitEncryptionKey
-        check_database_encryption_key(encryption_key: TD.config.encryption_key).then do
-          @ready_condition_mutex.synchronize do
-            @ready = true
-            @ready_condition.broadcast
-          end
+        set_tdlib_parameters(**@config)
+        @ready_condition_mutex.synchronize do
+          @ready = true
+          @ready_condition.broadcast
         end
       else
         # do nothing


### PR DESCRIPTION
Telegram no longer supports check encryption key. Changes only affect the pending verification state and unnecessary configurations