### PR TITLE
gem :dry-configurable dependecy updated to 1.2.0

### DIFF
--- a/lib/tdlib-ruby.rb
+++ b/lib/tdlib-ruby.rb
@@ -16,19 +16,19 @@ module TD
   setting :encryption_key
 
   setting :client do
-    setting :api_id, &:to_i
+    setting :api_id, default: 0
     setting :api_hash
-    setting :use_test_dc, false
-    setting :database_directory, "#{Dir.home}/.tdlib-ruby/db"
-    setting :files_directory, "#{Dir.home}/.tdlib-ruby/data"
-    setting :use_file_database, true
-    setting :use_chat_info_database, true
-    setting :use_secret_chats, true
-    setting :use_message_database, true
-    setting :system_language_code, 'en'
-    setting :device_model, 'Ruby TD client'
-    setting :system_version, 'Unknown'
-    setting :application_version, '1.0'
+    setting :use_test_dc, default: false
+    setting :database_directory, default: "#{Dir.home}/.tdlib-ruby/db"
+    setting :files_directory, default: "#{Dir.home}/.tdlib-ruby/data"
+    setting :use_file_database, default: true
+    setting :use_chat_info_database, default: true
+    setting :use_secret_chats, default: true
+    setting :use_message_database, default: true
+    setting :system_language_code, default: 'en'
+    setting :device_model, default: 'Ruby TD client'
+    setting :system_version, default: 'Unknown'
+    setting :application_version, default: '1.0'
   end
 end
 

--- a/lib/tdlib/version.rb
+++ b/lib/tdlib/version.rb
@@ -1,4 +1,4 @@
 module TD
   # tdlib-ruby version
-  VERSION = "3.0.4"
+  VERSION = "3.0.5"
 end

--- a/tdlib-ruby.gemspec
+++ b/tdlib-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'dry-configurable', '~> 0.9'
+  gem.add_runtime_dependency 'dry-configurable', '~> 1.2.0'
   gem.add_runtime_dependency 'concurrent-ruby',  '~> 1.1'
   gem.add_runtime_dependency 'ffi',              '~> 1.15.0'
   gem.add_runtime_dependency 'tdlib-schema'


### PR DESCRIPTION
Updates `dry-configuration` gem depency to `1.2.0` version. My purpose is using fresh `telegram-bot-ruby` together with `tdlib-ruby`